### PR TITLE
Fix some issues with narrow Python builds and add a little more testing

### DIFF
--- a/test.py
+++ b/test.py
@@ -30,6 +30,30 @@ def test(text1, text2, diff_function):
 
 	print ("")
 
+	changes = diff_function(
+		text1, text2,
+		timelimit=15,
+		checklines=False,
+		cleanup_semantic=True,
+		counts_only=True)
+
+	t1pos, t2pos = 0, 0
+	for op, length in changes:
+		if op == '=':
+			text = text1[t1pos:t1pos + length]
+			t1pos += length
+			t2pos += length
+		elif op == '+':
+			text = text2[t2pos:t2pos + length]
+			t2pos += length
+		elif op == '-':
+			text = text1[t1pos:t1pos + length]
+			t1pos += length
+		print(op, repr(text))
+
+	print ("")
+
 test(u"this is a test", u"this program is not \u2192 a test", diff)
+test(u"\U0001f37e", u"\U0001f37f", diff)  # surrogate pair in UTF-16
 test(b"this is a test", b"this program is not ==> a test", diff_bytes)
 	


### PR DESCRIPTION
The surrogate pair test demonstrates the issue with unpaired surrogates--on narrow builds it will show as two characters with the second one changing between the two texts, and on wide builds it will show as two different one-character strings. This is not a bug with the library, just a consequence of how narrow builds of Python treat strings.

The counts_only test is just to make sure the counts line up right.
