### PR TITLE
Add parameter for cleanupEfficiency

### DIFF
--- a/interface.cpp
+++ b/interface.cpp
@@ -146,6 +146,7 @@ diff_match_patch_diff(PyObject *self, PyObject *args, PyObject *kwargs)
     float timelimit = 0.0;
     int checklines = 1;
     int cleanupSemantic = 1;
+    int cleanupEfficient = 0;
     int counts_only = 1;
     int as_patch = 0;
     char format_spec[64];
@@ -156,14 +157,15 @@ diff_match_patch_diff(PyObject *self, PyObject *args, PyObject *kwargs)
         strdup("timelimit"),
         strdup("checklines"),
         strdup("cleanup_semantic"),
+        strdup("cleanup_efficient"),
         strdup("counts_only"),
         strdup("as_patch"),
         NULL };
 
-    sprintf(format_spec, "%c%c|fbbbb", FMTSPEC, FMTSPEC);
+    sprintf(format_spec, "%c%c|fbbbbb", FMTSPEC, FMTSPEC);
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, format_spec, kwlist,
                                      &a, &b,
-                                     &timelimit, &checklines, &cleanupSemantic,
+                                     &timelimit, &checklines, &cleanupSemantic, &cleanupEfficient,
                                      &counts_only, &as_patch))
         return NULL;
 
@@ -173,15 +175,17 @@ diff_match_patch_diff(PyObject *self, PyObject *args, PyObject *kwargs)
     DMP dmp;
 
     PyObject *opcodes[3];
-    opcodes[dmp.DELETE] = PyString_FromString("-");
-    opcodes[dmp.INSERT] = PyString_FromString("+");
-    opcodes[dmp.EQUAL] = PyString_FromString("=");
+    opcodes[dmp.DELETE] = PyString_FromString("-1");
+    opcodes[dmp.INSERT] = PyString_FromString("1");
+    opcodes[dmp.EQUAL] = PyString_FromString("0");
 
     dmp.Diff_Timeout = timelimit;
     typename DMP::Diffs diff = dmp.diff_main(traits::to_string(a), traits::to_string(b), checklines);
 
     if (cleanupSemantic)
         dmp.diff_cleanupSemantic(diff);
+    else if (cleanupEfficient)
+        dmp.diff_cleanupEfficiency(diff);
 
     if (as_patch) {
         typename DMP::Patches patch = dmp.patch_make(traits::to_string(a), diff);

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -59,24 +59,24 @@ class DiffTests(unittest.TestCase):
         self.assertDiffString(
             'this is a test',
             'this is a test',
-            [('=', 'this is a test')],
-            [('=', 14)],
+            [('0', 'this is a test')],
+            [('0', 14)],
         )
 
         self.assertDiffString(
             'this is a test',
             'this program is not \u2192 a test',
             [
-                ('=', 'this '),
-                ('-', 'is'),
-                ('+', 'program is not \u2192'),
-                ('=', ' a test'),
+                ('0', 'this '),
+                ('-1', 'is'),
+                ('1', 'program is not \u2192'),
+                ('0', ' a test'),
             ],
             [
-                ('=', 5),
-                ('-', 2),
-                ('+', 16),
-                ('=', 7),
+                ('0', 5),
+                ('-1', 2),
+                ('1', 16),
+                ('0', 7),
             ]
         )
 
@@ -91,24 +91,24 @@ class DiffTests(unittest.TestCase):
         self.assertDiffBytes(
             b'this is a test',
             b'this is a test',
-            [('=', 'this is a test')],
-            [('=', 14)],
+            [('0', 'this is a test')],
+            [('0', 14)],
         )
 
         self.assertDiffBytes(
             b'this is a test',
             b'this program is not ==> a test',
             [
-                ('=', 'this '),
-                ('-', 'is'),
-                ('+', 'program is not ==>'),
-                ('=', ' a test'),
+                ('0', 'this '),
+                ('-1', 'is'),
+                ('1', 'program is not ==>'),
+                ('0', ' a test'),
             ],
             [
-                ('=', 5),
-                ('-', 2),
-                ('+', 18),
-                ('=', 7),
+                ('0', 5),
+                ('-1', 2),
+                ('1', 18),
+                ('0', 7),
             ]
         )
 
@@ -117,11 +117,11 @@ class DiffTests(unittest.TestCase):
             '\U0001f37e',
             '\U0001f37f',
             [
-                ('-', u'\U0001f37e'),
-                ('+', u'\U0001f37f')
+                ('-1', u'\U0001f37e'),
+                ('1', u'\U0001f37f')
             ],
             [
-                ('-', 1),
-                ('+', 1),
+                ('-1', 1),
+                ('1', 1),
             ]
         )


### PR DESCRIPTION
Currently, the interface only exposes a parameter for `cleanupSemantic`.  Ideally, the interface would also expose `cleanupEfficency`.  This PR adds `cleanupEfficency` as an option for the python interface.

Less urgently, this also makes the symbols for deletion, insertion, and equality match the upstream library.