### PR TITLE
Rename import from diff_match_patch to fast_diff_match_patch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ First::
 
 Then write (this is Python 3)::
 
-	from diff_match_patch import diff
+	from fast_diff_match_patch import diff
 
 	changes = diff("Hello world.", "Goodbye moon.",
 		timelimit=0, checklines=False)
@@ -63,3 +63,10 @@ And to test without installing::
 
  PYTHONPATH=build/lib.linux-x86_64-2.7/ python test.py
  PYTHONPATH=build/lib.linux-x86_64-3.4/ python3 test.py
+
+Changelog
+---------
+
+2.0.0 (unreleased)
+******************
+* Rename package import from `diff_match_patch` to `fast_diff_match_patch` to avoid import naming collision with `<https://pypi.org/project/diff-match-patch/>`_.

--- a/interface.cpp
+++ b/interface.cpp
@@ -302,9 +302,9 @@ static PyMethodDef MyMethods[] = {
 };
 
 PyMODINIT_FUNC
-initdiff_match_patch(void)
+initfast_diff_match_patch(void)
 {
-    (void) Py_InitModule("diff_match_patch", MyMethods);
+    (void) Py_InitModule("fast_diff_match_patch", MyMethods);
 }
 #endif
 
@@ -335,7 +335,7 @@ static PyMethodDef MyMethods[] = {
 
 static struct PyModuleDef mymodule = {
    PyModuleDef_HEAD_INIT,
-   "diff_match_patch",   /* name of module */
+   "fast_diff_match_patch",   /* name of module */
    NULL, /* module documentation, may be NULL */
    -1,       /* size of per-interpreter state of the module,
                 or -1 if the module keeps state in global variables. */
@@ -343,7 +343,7 @@ static struct PyModuleDef mymodule = {
 };
 
 PyMODINIT_FUNC
-PyInit_diff_match_patch(void)
+PyInit_fast_diff_match_patch(void)
 {
     return PyModule_Create(&mymodule);
 }

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ from setuptools import setup, find_packages, Extension
 # python setup.py sdist bdist_wheel
 # twine upload dist/*
 
-module1 = Extension('diff_match_patch',
+module1 = Extension('fast_diff_match_patch',
                     sources = ['interface.cpp'],
                     include_dirs = [],
                     libraries = [])
 
 setup(
-    name='diff_match_patch_python',
-    version='1.0.2',
+    name='fast_diff_match_patch',
+    version='2.0.0',
     description=u'A Python extension module that wraps Google\'s diff_match_patch C++ implementation for very fast string comparisons. Version 1.0.2 fixes a build issue on Macs.',
     long_description=open("README.rst").read(),
     author=u'Joshua Tauberer',

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import sys
 import unittest
 
-import diff_match_patch
+import fast_diff_match_patch as diff_match_patch
 
 if sys.version_info[0] == 3:
     diff = diff_match_patch.diff

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import unittest
 import sys
 
-import diff_match_patch
+import fast_diff_match_patch as diff_match_patch
 
 if sys.version_info[0] == 3:
     diff = diff_match_patch.diff


### PR DESCRIPTION
Coming back to #4 after ... 5 years? 😬

Here's an attempt to rename the package import from `import diff_match_patch` to `import fast_diff_match_patch`.

I bumped the version to 2.0.0 instead of renaming the PyPI package, since that struck me as less confusing to document. You could do one and then the other though.