### PR TITLE
Update the 2.0.0 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Changes in version 2.0.0
 * The import has been renamed from `diff_match_patch` to `fast_diff_match_patch` to avoid an import naming collision with https://pypi.org/project/diff-match-patch/ and the package name has been updated to match the import name.
 * In previous versions of this package, separate `diff_bytes` (Py3), `diff_unicode` and `diff_str` (Py2)
 methods were available. They have been merged into a single `diff` method that checks the type of the arguments passed.)
+* `cleanup_semantic` has been renamed to `cleanup`, which takes one of three options (see above)
 * On Windows, an exception will be thrown if a string has characters outside of the Basic Multilingual Plane.
 
 Building from source


### PR DESCRIPTION
It looks [from this commit](https://github.com/JoshData/fast_diff_match_patch/pull/11), and the releases [here](https://pypi.org/project/fast-diff-match-patch/#history) like this came before version 1.0.3, but I think it feels fine to put it in with the 2.0.0 changelog anyway, just to keep it simple, since nobody has complained so far.

Thanks again for the amazing package.